### PR TITLE
Refresh public project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,55 @@
-# Blockchain
-Blockchain based projects in various fields and use-cases for the same
+﻿# Blockchain Learning Lab
 
-### Auction Project
-- To understand decentralization concept and its actual use. A good to start project.
-- Simple to understand Solidity contract.
+A learning lab of blockchain projects and experiments. The repository groups Solidity basics, token work, auctions, decentralized games, chat examples, and HashItOut-style project work.
 
-### P2P Chat App
-- Using Web RTC chat system to understand message passing and communication in Blockchain.
+## Repository Status
 
-### DecentralizedGames
-- Understanding Use Case of CryptoKitties.
+- Current role: Collection of blockchain experiments covering auctions, chat, games, tokens, Solidity, and Truffle-based projects
+- Documentation status: refreshed for public review
+- Primary audience: engineers, product reviewers, and collaborators evaluating the project context
 
-### Solidity
-- Simple to understand solidity codes. Good to start learning.
+## What This Project Does
 
-### Token
-- Understanding various Tokens Use case in Blockchain.
+- Multiple Solidity examples and project folders
+- Auction, token, chat, game, and hash-oriented experiments
+- Requirements file for Python-adjacent tooling
+- Structured archive of learning artifacts
 
-### Whisper Chat
-- To understand difference between Centralized and Decentralized chat system to some extent and usage of Whisper Chat in Blockchain
+## Technology Stack
+
+- Solidity
+- Truffle-style project artifacts in selected folders
+- Python requirements where applicable
+- Multiple independent project folders
+
+## Repository Map
+
+- Solidity/ contains language exercises
+- Token/ and Auction Project/ contain domain-specific experiments
+- CentralizedChatApp/, WhisperChatApp/, and DecentralizedGames/ contain app experiments
+- HashItOut/ contains a larger project artifact
+
+## Getting Started
+
+- Open the specific subproject before installing dependencies
+- Install only the tooling required by that subproject
+- Use local blockchain networks for contract experiments
+- Review each folder README or source files before running commands
+
+## Documentation
+
+- docs/overview.md - product context, users, scope, and outcomes
+- docs/architecture.md - components, data flow, and sequence diagrams
+- docs/operations.md - setup, validation, maintenance, and known risks
+
+## Known Limitations
+
+- Subprojects may require different tool versions
+- The repository is an educational archive, not a single production application
+- Some examples may reflect older ecosystem practices
+
+## Notes For Future Maintainers
+
+This repository documents the original project intent and the implementation shape visible in the codebase. Before production use, review dependencies, environment configuration, data handling, and deployment assumptions against current standards.
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+﻿# Architecture
+
+The repository is a multi-project lab. Each folder should be evaluated independently, with shared documentation serving as a map across concepts.
+
+## Component View
+
+```mermaid
+flowchart LR
+  Actor["Developer learner"] --> Entry["Project folder"]
+  Entry --> Service["Experiment-specific app or contract"]
+  Service --> Data["Local chain or local files"]
+  Service --> External["Solidity tooling and blockchain clients"]
+```
+
+## Key Components
+
+- Solidity basics
+- Auction and token experiments
+- Chat and decentralized game examples
+- HashItOut project folder
+
+## Main Workflow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Client
+  participant App
+  participant Store
+  User->>Client: Selects a learning module
+  Client->>App: Runs or reads project code
+  App->>Store: Validate and persist state
+  Store-->>App: Local result or contract state changes
+  App-->>Client: Reviews behavior and lessons
+  Client-->>User: Present updated result
+```
+
+## Design Considerations
+
+- Keep each experiment independently understandable
+- Document expected tool versions per folder
+- Promote historical context over production claims
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,30 @@
+﻿# Operations
+
+These notes capture the practical work needed to run, maintain, or modernize the repository from its current state.
+
+## Local Operation
+
+- Open the specific subproject before installing dependencies
+- Install only the tooling required by that subproject
+- Use local blockchain networks for contract experiments
+- Review each folder README or source files before running commands
+
+## Validation
+
+- Validate one subproject at a time
+- Use local networks for Solidity experiments
+- Record tool versions when a subproject is revived
+
+## Maintenance Notes
+
+- Add per-folder README files over time
+- Keep obsolete dependencies documented as historical context
+- Avoid presenting learning artifacts as audited contracts
+
+## Operational Risks
+
+- Subprojects may require different tool versions
+- The repository is an educational archive, not a single production application
+- Some examples may reflect older ecosystem practices
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+﻿# Overview
+
+This repository is best treated as a portfolio of experiments rather than one deployable product. Its value is in showing progression through blockchain concepts and project patterns.
+
+## Problem Space
+
+Blockchain learning is often fragmented. A lab repository helps connect low-level Solidity exercises with higher-level decentralized application ideas.
+
+## Primary Users
+
+- Developers reviewing blockchain learning progression
+- Students exploring Solidity and decentralized application patterns
+- Maintainers organizing historical experiments
+
+## Scope
+
+- Learning artifacts across multiple blockchain topics
+- Folder-level project organization
+- Modernization guidance for old examples
+
+## Outcomes To Evaluate
+
+- Readers can navigate the repo by concept
+- Experiments are framed honestly as educational work
+- Reusable ideas can be separated from obsolete tooling
+
+


### PR DESCRIPTION
## Summary
- Refresh the public README with a neutral project overview, stack, setup notes, and limitations.
- Add standard documentation under docs/ where useful: overview, architecture, product, and operations.
- Keep the content professional and repository-focused without strategy-specific document names.

## Validation
- Documentation-only change.
- Verified README docs links locally across the refresh batch.